### PR TITLE
Updated OpenAPI definitions for SecurityGroup and ServiceCredential

### DIFF
--- a/public/doc/openapi-3-v0.0.2.json
+++ b/public/doc/openapi-3-v0.0.2.json
@@ -1705,6 +1705,9 @@
                   "$ref": "#/components/schemas/InventoryCollectionServiceOfferingNode"
                 },
                 {
+                  "$ref": "#/components/schemas/InventoryCollectionServiceCredential"
+                },
+                {
                   "$ref": "#/components/schemas/InventoryCollectionServicePlan"
                 },
                 {
@@ -1815,6 +1818,7 @@
                   "service_offering_icons": "#/components/schemas/InventoryCollectionServiceOfferingIcon",
                   "service_offerings": "#/components/schemas/InventoryCollectionServiceOffering",
                   "service_offering_nodes": "#/components/schemas/InventoryCollectionServiceOfferingNode",
+                  "service_credentials": "#/components/schemas/InventoryCollectionServiceCredential",
                   "service_plans": "#/components/schemas/InventoryCollectionServicePlan",
                   "source_regions": "#/components/schemas/InventoryCollectionSourceRegion",
                   "subnets": "#/components/schemas/InventoryCollectionSubnet",
@@ -2613,6 +2617,30 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/SecurityGroupTag"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "InventoryCollectionServiceCredential": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ServiceCredential"
+            }
+          },
+          "partial_data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ServiceCredential"
             }
           }
         },
@@ -3808,9 +3836,8 @@
                 "nullable": true,
                 "type": "string"
               },
-              "network_id": {
-                "nullable": true,
-                "type": "integer"
+              "network": {
+                "$ref": "#/components/schemas/NetworkReference"
               },
               "orchestration_stack": {
                 "$ref": "#/components/schemas/OrchestrationStackReference"
@@ -3917,6 +3944,89 @@
           }
         ]
       },
+      "ServiceCredential": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/InventoryObject"
+          },
+          {
+            "type": "object",
+            "required": [
+              "source_ref"
+            ],
+            "properties": {
+              "archived_at": {
+                "format": "date-time",
+                "nullable": true,
+                "type": "string"
+              },
+              "description": {
+                "nullable": true,
+                "type": "string"
+              },
+              "name": {
+                "nullable": true,
+                "type": "string"
+              },
+              "resource_timestamp": {
+                "format": "date-time",
+                "nullable": true,
+                "type": "string"
+              },
+              "source_created_at": {
+                "format": "date-time",
+                "nullable": true,
+                "type": "string"
+              },
+              "source_ref": {
+                "type": "string"
+              },
+              "source_updated_at": {
+                "format": "date-time",
+                "nullable": true,
+                "type": "string"
+              },
+              "type_name": {
+                "nullable": true,
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "ServiceCredentialReference": {
+        "type": "object",
+        "nullable": true,
+        "required": [
+          "inventory_collection_name",
+          "reference",
+          "ref"
+        ],
+        "properties": {
+          "inventory_collection_name": {
+            "type": "string",
+            "pattern": "^service_credentials$"
+          },
+          "reference": {
+            "type": "object",
+            "required": [
+              "source_ref"
+            ],
+            "properties": {
+              "source_ref": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "ref": {
+            "type": "string",
+            "pattern": "^manager_ref$"
+          }
+        },
+        "additionalProperties": false
+      },
       "ServiceInstance": {
         "allOf": [
           {
@@ -3953,6 +4063,9 @@
               },
               "root_service_instance": {
                 "$ref": "#/components/schemas/ServiceInstanceReference"
+              },
+              "service_credential": {
+                "$ref": "#/components/schemas/ServiceCredentialReference"
               },
               "service_inventory": {
                 "$ref": "#/components/schemas/ServiceInventoryReference"
@@ -4018,6 +4131,9 @@
               },
               "root_service_instance": {
                 "$ref": "#/components/schemas/ServiceInstanceReference"
+              },
+              "service_credential": {
+                "$ref": "#/components/schemas/ServiceCredentialReference"
               },
               "service_instance": {
                 "$ref": "#/components/schemas/ServiceInstanceReference"
@@ -4248,6 +4364,9 @@
                 "nullable": true,
                 "type": "string"
               },
+              "service_credential": {
+                "$ref": "#/components/schemas/ServiceCredentialReference"
+              },
               "service_inventory": {
                 "$ref": "#/components/schemas/ServiceInventoryReference"
               },
@@ -4368,6 +4487,9 @@
               },
               "root_service_offering": {
                 "$ref": "#/components/schemas/ServiceOfferingReference"
+              },
+              "service_credential": {
+                "$ref": "#/components/schemas/ServiceCredentialReference"
               },
               "service_inventory": {
                 "$ref": "#/components/schemas/ServiceInventoryReference"


### PR DESCRIPTION
SecurityGroup defined "network_id" as an integer instead of "network": NetworkReference

Also generated previously added ServiceCredential

---

* [ ] **depends on** https://github.com/RedHatInsights/topological_inventory-core/pull/163