### PR TITLE
Bump core to 1.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'rails',               '~> 5.2.2'
 
 gem 'manageiq-messaging'
 
-gem 'topological_inventory-core', :git => 'https://github.com/RedHatInsights/topological_inventory-core', :branch => 'master'
+gem 'topological_inventory-core', '~> 1.0.0'
 
 group :development, :test do
   gem 'byebug'


### PR DESCRIPTION
**Issue**: https://github.com/RedHatInsights/topological_inventory-core/issues/190

Merged PRs can't affect production with incompatible code

---

- [x] **depends on** https://github.com/RedHatInsights/topological_inventory-core/pull/189 **[ requires RubyGems release ]**