### PR TITLE
Fix messaging client to use MiQ messaging since the common gem doesn'…

### DIFF
--- a/lib/topological_inventory/ingress_api/messaging_client.rb
+++ b/lib/topological_inventory/ingress_api/messaging_client.rb
@@ -39,7 +39,7 @@ module TopologicalInventory
         def new_messaging_client(retry_max = 1)
           retry_count = 0
           begin
-            Insights::Messaging::Client.open(
+            ManageIQ::Messaging::Client.open(
               :encoding => "json",
               :host     => ENV["QUEUE_HOST"] || "localhost",
               :port     => ENV["QUEUE_PORT"] || "9092",


### PR DESCRIPTION
…t have the messaging client

I got a bit gratuitous with my renaming. And the specs don't instantiate the client. 

cc @syncrou 