### PR TITLE
Changed error handling to rdkafka classes 2

### DIFF
--- a/lib/topological_inventory/ingress_api/messaging_client.rb
+++ b/lib/topological_inventory/ingress_api/messaging_client.rb
@@ -48,7 +48,7 @@ module TopologicalInventory
               :protocol => :Kafka,
             )
           end
-        rescue Kafka::ConnectionError
+        rescue ::Rdkafka::RdkafkaError
           retry_count += 1
           retry unless retry_count > retry_max
         end


### PR DESCRIPTION
Follower of #102, I missed one place with Kafka error class

---

[RHCLOUD-10003](https://issues.redhat.com/browse/RHCLOUD-10003)