### PR TITLE
Don't use Thread storage for messaging client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'insights-api-common', '~> 4.0'
 gem 'json-schema',         '~> 2.8'
 gem 'manageiq-loggers',    "~> 0.4.0", ">= 0.4.2"
 gem 'prometheus-client',   '~> 0.8.0'
-gem 'puma',                '~> 4.3.3', '>= 4.3.5'
+gem 'puma',                '~> 4.3.5', '>= 4.3.5'
 gem 'rack-cors',           '>= 1.0.4'
 gem 'rails',               '~> 5.2.2'
 

--- a/lib/topological_inventory/ingress_api/messaging_client.rb
+++ b/lib/topological_inventory/ingress_api/messaging_client.rb
@@ -5,13 +5,11 @@ module TopologicalInventory
 
       included do
         private_class_method :messaging_client,
-                             :messaging_client=,
                              :new_messaging_client
       end
 
       module ClassMethods
         def with_messaging_client
-          messaging_client ||= new_messaging_client
           raise if messaging_client.nil?
 
           begin
@@ -31,11 +29,7 @@ module TopologicalInventory
         end
 
         def messaging_client
-          Thread.current[:messaging_client]
-        end
-
-        def messaging_client=(value)
-          Thread.current[:messaging_client] = value
+          @messaging_client ||= new_messaging_client
         end
 
         def new_messaging_client(retry_max = 1)


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-10284

Dug into this because boredom on a Sunday, it appears with the `Thread[:messaging_client]` we are creating a new messaging client every time, and each one of those is a thread. Pretty quickly we run out of threads and nothing gets processed anymore.

By memoizing `messaging_client` as a class var we only instantiate one rdkafka producer. 

---

Not sure why this behavior changed - I'll go back and validate that it worked with `ruby-kafka` but I'm not sure either way. 

cc @syncrou @slemrmartin
