### PR TITLE
Rubocop rules from insights-api-common + yamllint

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,9 +2,9 @@
 version: '2'
 prepare:
   fetch:
-  - url: https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml
+  - url: https://raw.githubusercontent.com/RedHatInsights/insights-api-common-rails/master/.rubocop_base.yml
     path: ".rubocop_base.yml"
-  - url: https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_cc_base.yml
+  - url: https://raw.githubusercontent.com/RedHatInsights/insights-api-common-rails/master/.rubocop_cc_base.yml
     path: ".rubocop_cc_base.yml"
 checks:
   argument-count:
@@ -28,4 +28,4 @@ plugins:
   rubocop:
     enabled: true
     config: ".rubocop_cc.yml"
-    channel: rubocop-0-69
+    channel: rubocop-1-0

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,3 @@
 inherit_from:
-- https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml
+- https://raw.githubusercontent.com/RedHatInsights/insights-api-common-rails/master/.rubocop_base.yml
 - .rubocop_local.yml

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,8 @@
+---
+ignore: |
+
+extends: relaxed
+
+rules:
+  line-length:
+    max: 128

--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,10 @@ source 'https://rubygems.org'
 plugin 'bundler-inject', '~> 1.1'
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
-gem "cloudwatchlogger",    "~> 0.2.1"
+gem 'cloudwatchlogger',    '~> 0.2.1'
 gem 'insights-api-common', '~> 4.0'
 gem 'json-schema',         '~> 2.8'
-gem 'manageiq-loggers',    "~> 0.4.0", ">= 0.4.2"
+gem 'manageiq-loggers',    '~> 0.4.0', '>= 0.4.2'
 gem 'prometheus-client',   '~> 0.8.0'
 gem 'puma',                '~> 4.3.5', '>= 4.3.5'
 gem 'rack-cors',           '>= 1.0.4'
@@ -15,10 +15,10 @@ gem 'rails',               '~> 5.2.2'
 gem 'manageiq-messaging', '~> 1.0.0'
 
 group :development, :test do
-  gem 'byebug'
-  gem 'rubocop',             "~>0.69.0", :require => false
-  gem 'rubocop-performance', "~>1.3",    :require => false
-  gem "simplecov",           "~>0.17.1"
+  gem 'rubocop',             '~> 1.0.0', :require => false
+  gem 'rubocop-performance', '~> 1.8',   :require => false
+  gem 'rubocop-rails',       '~> 2.8',   :require => false
+  gem 'simplecov',           '~>0.17.1'
 end
 
 group :test do


### PR DESCRIPTION
Because of https://github.com/ManageIQ/guides/pull/443 rubocop rules were moved to another repo. 
So we are moving the file to our common repo.

* [x] depends on https://github.com/RedHatInsights/insights-api-common-rails/pull/211

---

[RHCLOUD-10237](https://issues.redhat.com/browse/RHCLOUD-10237)
