### PR TITLE
Add /health endpoint for Liveness Probe

### DIFF
--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -1,0 +1,3 @@
+class StatusController < ::ApplicationController
+  include Insights::API::Common::Status::Api
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
   #   prefix = File.join(ENV["PATH_PREFIX"], ENV["APP_NAME"]).gsub(/^\/+|\/+$/, "")
   # end
 
+  get "/health", :to => "status#health"
+
   namespace :topological_inventory do
     scope :as => :ingress_api, :module => "ingress_api", :path => prefix do
       namespace :v0x0x2, :path => "0.0.2" do


### PR DESCRIPTION
Seeing problems in prod where one of the ingress pods is taking forever, I'm wondering if a liveness probe would fix it, and realized we don't have the `/health` endpoint on ingress yet. So I'm adding it.

e2e-deploy fix, goes after: https://github.com/RedHatInsights/e2e-deploy/pull/2551
